### PR TITLE
Fixed rotation issue on results recipe list

### DIFF
--- a/app/src/main/java/edu/mills/findeatfood/ResultsFragment.java
+++ b/app/src/main/java/edu/mills/findeatfood/ResultsFragment.java
@@ -29,6 +29,10 @@ public class ResultsFragment extends ListFragment {
     private ProgressDialog progress;
     private int startPosition;
 
+    public ResultsFragment(){
+        setRetainInstance(true);
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);


### PR DESCRIPTION
resolved #44. Now saves results recipe list when the device is rotated. 